### PR TITLE
Update Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -69,7 +69,7 @@ ENV BIN /usr/local/bin
 ## Python 3 stuff
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-RUN pip install argparse pysam networkx lmdb
+RUN pip install pysam networkx lmdb
 
 WORKDIR $SRC
 


### PR DESCRIPTION
argparse is included in the stdlib, don't need to install it from PyPI