### PR TITLE
WDL resources disk autoscale and ram/cpu minimization for pre/post process.

### DIFF
--- a/WDL/LRAA.wdl
+++ b/WDL/LRAA.wdl
@@ -50,10 +50,7 @@ workflow LRAA_wf {
                 genome_fasta = referenceGenome,
                 annot_gtf = annot_gtf,
                 chromosomes_want_partitioned = main_chromosomes,
-            
                 docker = docker,
-                memoryGB = memoryGB,
-                diskSizeGB = diskSizeGB
             }
      
                   
@@ -88,8 +85,6 @@ workflow LRAA_wf {
                 gtfFiles = LRAA_scatter.LRAA_gtf,
                 outputFilePrefix = sample_id + ".LRAA",
                 docker = docker,
-                memoryGB = memoryGB,
-                diskSizeGB = diskSizeGB
         }
     }
 
@@ -133,8 +128,6 @@ task mergeResults {
         Array[File] gtfFiles
         String outputFilePrefix
         String docker
-        Int memoryGB
-        Int diskSizeGB
     }
 
     command <<<
@@ -199,8 +192,8 @@ task mergeResults {
     runtime {
         docker: docker
         cpu: 1
-        memory: "~{memoryGB} GiB"
-        disks: "local-disk ~{diskSizeGB} HDD"
+        memory: "4 GiB"
+        disks: "local-disk " + ceil((size(quantExprFiles, "GB") + size(quantTrackingFiles, "GB") + size(gtfFiles, "GB")) * 2.2 + 5) + " SSD"
     }
 }
 
@@ -217,6 +210,7 @@ task count_bam {
   runtime {
     docker: "us-central1-docker.pkg.dev/methods-dev-lab/lraa/lraa:latest"
     disks: "local-disk " + ceil(2 * size(bam, "GB") ) + " HDD"
+    cpu: 1
     memory: "4G"
   }
   output {

--- a/WDL/subwdls/Partition_data_by_chromosome.wdl
+++ b/WDL/subwdls/Partition_data_by_chromosome.wdl
@@ -8,8 +8,6 @@ task partition_by_chromosome_task {
         String chromosomes_want_partitioned # ex. "chr1 chr2 chr3 ..."
 
         String docker
-        Int memoryGB
-        Int diskSizeGB
     }
 
     command <<<
@@ -53,8 +51,9 @@ task partition_by_chromosome_task {
     runtime {
         docker: docker
         bootDiskSizeGb: 30
-        memory: "~{memoryGB} GiB"
-        disks: "local-disk ~{diskSizeGB} HDD"
+        cpu: 1
+        memory: "4 GiB"
+        disks: "local-disk " + ceil((size(inputBAM, "GB") + size(genome_fasta, "GB") + size(annot_gtf, "GB")) * 2.2 + 5) + " SSD"
     }
 }
 
@@ -78,8 +77,6 @@ workflow partition_by_chromosome {
           genome_fasta=genome_fasta,
           annot_gtf=annot_gtf,
           chromosomes_want_partitioned=chromosomes_want_partitioned,
-          memoryGB = memoryGB,
-          diskSizeGB = diskSizeGB,
           docker = docker
       
     }


### PR DESCRIPTION
Autoscale disk size to input for tasks with easily predictable disk use (split and merge).

Set resources to 1vCPU and 4GB or RAM for I/O tasks that only stream data, to save on cost and make call caching more consistent